### PR TITLE
Updated fast_rcnn.py with correct kept_indices

### DIFF
--- a/detectron2/modeling/roi_heads/fast_rcnn.py
+++ b/detectron2/modeling/roi_heads/fast_rcnn.py
@@ -164,11 +164,14 @@ def fast_rcnn_inference_single_image(
         keep = keep[:topk_per_image]
     boxes, scores, filter_inds = boxes[keep], scores[keep], filter_inds[keep]
 
+    # account for non-finite inputs
+    kept_inds = valid_mask.nonzero()[filter_inds[:, 0], 0]
+
     result = Instances(image_shape)
     result.pred_boxes = Boxes(boxes)
     result.scores = scores
     result.pred_classes = filter_inds[:, 1]
-    return result, filter_inds[:, 0]
+    return result, kept_inds
 
 
 class FastRCNNOutputs:


### PR DESCRIPTION
``fast_rcnn_inference()`` is expected to return 

> kept_indices: (list[Tensor]): A list of 1D tensor of length of N, each element indicates
            the corresponding boxes/scores index in [0, Ri) from the input, for image i.

Yet ``fast_rcnn_inference_single_image()`` did not account for the potential removal of non-finite boxes/scores. 
The fix calculates the correct indices into the inputs. 